### PR TITLE
Add more KUnit tests for functions on drm_framebuffer.c

### DIFF
--- a/drivers/gpu/drm/tests/drm_framebuffer_test.c
+++ b/drivers/gpu/drm/tests/drm_framebuffer_test.c
@@ -441,8 +441,60 @@ static void drm_test_framebuffer_lookup(struct kunit *test)
 	KUNIT_EXPECT_NULL(test, fb2);
 }
 
+static void drm_test_framebuffer_init(struct kunit *test)
+{
+	struct drm_device_mock *mock = test->priv;
+	struct drm_device *dev = &mock->dev;
+	struct drm_device wrong_drm = { };
+	struct drm_format_info format = { };
+	struct drm_framebuffer fb1 = { .dev = dev, .format = &format };
+	struct drm_framebuffer *fb2;
+	struct drm_framebuffer_funcs funcs = { };
+	int ret;
+
+	/* Fails if fb->dev doesn't point to the drm_device passed on first arg */
+	fb1.dev = &wrong_drm;
+	ret = drm_framebuffer_init(dev, &fb1, &funcs);
+	KUNIT_EXPECT_EQ(test, ret, -EINVAL);
+	fb1.dev = dev;
+
+	/* Fails if fb.format isn't set */
+	fb1.format = NULL;
+	ret = drm_framebuffer_init(dev, &fb1, &funcs);
+	KUNIT_EXPECT_EQ(test, ret, -EINVAL);
+	fb1.format = &format;
+
+	ret = drm_framebuffer_init(dev, &fb1, &funcs);
+	KUNIT_EXPECT_EQ(test, ret, 0);
+
+	/*
+	 * Check if fb->funcs is actually set to the drm_framebuffer_funcs
+	 * passed to it
+	 */
+	KUNIT_EXPECT_PTR_EQ(test, fb1.funcs, &funcs);
+
+	/* The fb->comm should bet set to the current running process */
+	KUNIT_EXPECT_STREQ(test, fb1.comm, current->comm);
+
+	/* The fb->base should be sucefully initialized */
+	KUNIT_EXPECT_EQ(test, fb1.base.id, 1);
+	KUNIT_EXPECT_EQ(test, fb1.base.type, DRM_MODE_OBJECT_FB);
+	KUNIT_EXPECT_EQ(test, kref_read(&fb1.base.refcount), 1);
+	KUNIT_EXPECT_PTR_EQ(test, fb1.base.free_cb, &drm_framebuffer_free);
+
+	/* Checks if the fb is really published and findable */
+	fb2 = drm_framebuffer_lookup(dev, NULL, fb1.base.id);
+	KUNIT_EXPECT_PTR_EQ(test, fb2, &fb1);
+
+	/* There should be just that one fb initialized */
+	KUNIT_EXPECT_EQ(test, dev->mode_config.num_fb, 1);
+	KUNIT_EXPECT_PTR_EQ(test, dev->mode_config.fb_list.prev, &fb1.head);
+	KUNIT_EXPECT_PTR_EQ(test, dev->mode_config.fb_list.next, &fb1.head);
+}
+
 static struct kunit_case drm_framebuffer_tests[] = {
 	KUNIT_CASE(drm_test_framebuffer_cleanup),
+	KUNIT_CASE(drm_test_framebuffer_init),
 	KUNIT_CASE(drm_test_framebuffer_lookup),
 	KUNIT_CASE_PARAM(drm_test_framebuffer_create, drm_framebuffer_create_gen_params),
 	{ }

--- a/drivers/gpu/drm/tests/drm_framebuffer_test.c
+++ b/drivers/gpu/drm/tests/drm_framebuffer_test.c
@@ -8,6 +8,7 @@
 #include <kunit/test.h>
 
 #include <drm/drm_device.h>
+#include <drm/drm_drv.h>
 #include <drm/drm_mode.h>
 #include <drm/drm_framebuffer.h>
 #include <drm/drm_fourcc.h>
@@ -346,6 +347,10 @@ static int drm_framebuffer_test_init(struct kunit *test)
 	KUNIT_ASSERT_NOT_ERR_OR_NULL(test, mock);
 	dev = &mock->dev;
 
+	dev->driver = kunit_kzalloc(test, sizeof(*dev->driver), GFP_KERNEL);
+	KUNIT_ASSERT_NOT_ERR_OR_NULL(test, dev->driver);
+
+	idr_init_base(&dev->mode_config.object_idr, 1);
 	mutex_init(&dev->mode_config.fb_lock);
 	INIT_LIST_HEAD(&dev->mode_config.fb_list);
 	dev->mode_config.num_fb = 0;
@@ -414,8 +419,31 @@ static void drm_test_framebuffer_cleanup(struct kunit *test)
 	KUNIT_ASSERT_EQ(test, dev->mode_config.num_fb, 0);
 }
 
+static void drm_test_framebuffer_lookup(struct kunit *test)
+{
+	struct drm_device_mock *mock = test->priv;
+	struct drm_device *dev = &mock->dev;
+	struct drm_framebuffer fb1 = { };
+	struct drm_framebuffer *fb2;
+	uint32_t id = 0;
+	int ret;
+
+	ret = drm_mode_object_add(dev, &fb1.base, DRM_MODE_OBJECT_FB);
+	KUNIT_ASSERT_EQ(test, ret, 0);
+	id = fb1.base.id;
+
+	/* Looking for fb1 */
+	fb2 = drm_framebuffer_lookup(dev, NULL, id);
+	KUNIT_EXPECT_PTR_EQ(test, fb2, &fb1);
+
+	/* Looking for an inexsistent framebuffer */
+	fb2 = drm_framebuffer_lookup(dev, NULL, id + 1);
+	KUNIT_EXPECT_NULL(test, fb2);
+}
+
 static struct kunit_case drm_framebuffer_tests[] = {
 	KUNIT_CASE(drm_test_framebuffer_cleanup),
+	KUNIT_CASE(drm_test_framebuffer_lookup),
 	KUNIT_CASE_PARAM(drm_test_framebuffer_create, drm_framebuffer_create_gen_params),
 	{ }
 };

--- a/drivers/gpu/drm/tests/drm_framebuffer_test.c
+++ b/drivers/gpu/drm/tests/drm_framebuffer_test.c
@@ -317,11 +317,17 @@ static const struct drm_framebuffer_test drm_framebuffer_create_cases[] = {
 },
 };
 
+struct drm_device_mock {
+	struct drm_device dev;
+	void *private;
+};
+
 static struct drm_framebuffer *fb_create_mock(struct drm_device *dev,
 					      struct drm_file *file_priv,
 					      const struct drm_mode_fb_cmd2 *mode_cmd)
 {
-	int *buffer_created = dev->dev_private;
+	struct drm_device_mock *mock = container_of(dev, typeof(*mock), dev);
+	int *buffer_created = mock->private;
 	*buffer_created = 1;
 	return ERR_PTR(-EINVAL);
 }
@@ -332,16 +338,18 @@ static struct drm_mode_config_funcs mock_config_funcs = {
 
 static int drm_framebuffer_test_init(struct kunit *test)
 {
-	struct drm_device *mock;
+	struct drm_device_mock *mock;
+	struct drm_device *dev;
 
 	mock = kunit_kzalloc(test, sizeof(*mock), GFP_KERNEL);
 	KUNIT_ASSERT_NOT_ERR_OR_NULL(test, mock);
+	dev = &mock->dev;
 
-	mock->mode_config.min_width = MIN_WIDTH;
-	mock->mode_config.max_width = MAX_WIDTH;
-	mock->mode_config.min_height = MIN_HEIGHT;
-	mock->mode_config.max_height = MAX_HEIGHT;
-	mock->mode_config.funcs = &mock_config_funcs;
+	dev->mode_config.min_width = MIN_WIDTH;
+	dev->mode_config.max_width = MAX_WIDTH;
+	dev->mode_config.min_height = MIN_HEIGHT;
+	dev->mode_config.max_height = MAX_HEIGHT;
+	dev->mode_config.funcs = &mock_config_funcs;
 
 	test->priv = mock;
 	return 0;
@@ -350,11 +358,12 @@ static int drm_framebuffer_test_init(struct kunit *test)
 static void drm_test_framebuffer_create(struct kunit *test)
 {
 	const struct drm_framebuffer_test *params = test->param_value;
-	struct drm_device *mock = test->priv;
+	struct drm_device_mock *mock = test->priv;
+	struct drm_device *dev = &mock->dev;
 	int buffer_created = 0;
 
-	mock->dev_private = &buffer_created;
-	drm_internal_framebuffer_create(mock, &params->cmd, NULL);
+	mock->private = &buffer_created;
+	drm_internal_framebuffer_create(dev, &params->cmd, NULL);
 	KUNIT_EXPECT_EQ(test, params->buffer_created, buffer_created);
 }
 

--- a/drivers/gpu/drm/tests/drm_framebuffer_test.c
+++ b/drivers/gpu/drm/tests/drm_framebuffer_test.c
@@ -492,8 +492,57 @@ static void drm_test_framebuffer_init(struct kunit *test)
 	KUNIT_EXPECT_PTR_EQ(test, dev->mode_config.fb_list.next, &fb1.head);
 }
 
+static void mock_destroy_free(struct drm_framebuffer *fb)
+{
+	struct drm_device_mock *mock = container_of(fb->dev, typeof(*mock), dev);
+	int *buffer_freed = mock->private;
+	*buffer_freed = 1;
+}
+
+static struct drm_framebuffer_funcs mock_framebuffer_funcs_free = {
+	.destroy = mock_destroy_free,
+};
+
+static void drm_test_framebuffer_free(struct kunit *test)
+{
+	struct drm_device_mock *mock = test->priv;
+	struct drm_device *dev = &mock->dev;
+	struct drm_mode_object *obj;
+	struct drm_framebuffer fb = {
+		.dev = dev,
+		.funcs = &mock_framebuffer_funcs_free,
+	};
+	int buffer_freed = 0;
+	int id, ret;
+
+	mock->private = &buffer_freed;
+
+	/*
+	 * Case where the fb isn't registered. Just test if
+	 * drm_framebuffer_free calls fb->funcs->destroy
+	 */
+	drm_framebuffer_free(&fb.base.refcount);
+	KUNIT_EXPECT_EQ(test, buffer_freed, 1);
+
+	buffer_freed = 0;
+
+	ret = drm_mode_object_add(dev, &fb.base, DRM_MODE_OBJECT_FB);
+	KUNIT_ASSERT_EQ(test, ret, 0);
+	id = fb.base.id;
+
+	/* Now, test with the fb registered, that should end unregistered */
+	drm_framebuffer_free(&fb.base.refcount);
+	KUNIT_EXPECT_EQ(test, fb.base.id, 0);
+	KUNIT_EXPECT_EQ(test, buffer_freed, 1);
+
+	/* Test if the old id of the fb was really removed from the idr pool */
+	obj = drm_mode_object_find(dev, NULL, id, DRM_MODE_OBJECT_FB);
+	KUNIT_EXPECT_PTR_EQ(test, obj, NULL);
+}
+
 static struct kunit_case drm_framebuffer_tests[] = {
 	KUNIT_CASE(drm_test_framebuffer_cleanup),
+	KUNIT_CASE(drm_test_framebuffer_free),
 	KUNIT_CASE(drm_test_framebuffer_init),
 	KUNIT_CASE(drm_test_framebuffer_lookup),
 	KUNIT_CASE_PARAM(drm_test_framebuffer_create, drm_framebuffer_create_gen_params),

--- a/drivers/gpu/drm/tests/drm_framebuffer_test.c
+++ b/drivers/gpu/drm/tests/drm_framebuffer_test.c
@@ -10,6 +10,7 @@
 #include <drm/drm_device.h>
 #include <drm/drm_drv.h>
 #include <drm/drm_mode.h>
+#include <drm/drm_file.h>
 #include <drm/drm_framebuffer.h>
 #include <drm/drm_fourcc.h>
 #include <drm/drm_print.h>
@@ -321,6 +322,7 @@ static const struct drm_framebuffer_test drm_framebuffer_create_cases[] = {
 
 struct drm_device_mock {
 	struct drm_device dev;
+	struct drm_file file_priv;
 	void *private;
 };
 
@@ -342,13 +344,18 @@ static int drm_framebuffer_test_init(struct kunit *test)
 {
 	struct drm_device_mock *mock;
 	struct drm_device *dev;
+	struct drm_file *file_priv;
+	struct drm_driver *driver;
 
 	mock = kunit_kzalloc(test, sizeof(*mock), GFP_KERNEL);
 	KUNIT_ASSERT_NOT_ERR_OR_NULL(test, mock);
 	dev = &mock->dev;
+	file_priv = &mock->file_priv;
 
-	dev->driver = kunit_kzalloc(test, sizeof(*dev->driver), GFP_KERNEL);
-	KUNIT_ASSERT_NOT_ERR_OR_NULL(test, dev->driver);
+	driver = kunit_kzalloc(test, sizeof(*dev->driver), GFP_KERNEL);
+	KUNIT_ASSERT_NOT_ERR_OR_NULL(test, driver);
+	driver->driver_features = DRIVER_MODESET;
+	dev->driver = driver;
 
 	idr_init_base(&dev->mode_config.object_idr, 1);
 	mutex_init(&dev->mode_config.fb_lock);
@@ -360,6 +367,9 @@ static int drm_framebuffer_test_init(struct kunit *test)
 	dev->mode_config.max_height = MAX_HEIGHT;
 	dev->mode_config.funcs = &mock_config_funcs;
 
+	mutex_init(&file_priv->fbs_lock);
+	INIT_LIST_HEAD(&file_priv->fbs);
+
 	test->priv = mock;
 	return 0;
 }
@@ -368,8 +378,10 @@ static void drm_framebuffer_test_exit(struct kunit *test)
 {
 	struct drm_device_mock *mock = test->priv;
 	struct drm_device *dev = &mock->dev;
+	struct drm_file *file_priv = &mock->file_priv;
 
 	mutex_destroy(&dev->mode_config.fb_lock);
+	mutex_destroy(&file_priv->fbs_lock);
 }
 
 static void drm_test_framebuffer_create(struct kunit *test)
@@ -540,7 +552,85 @@ static void drm_test_framebuffer_free(struct kunit *test)
 	KUNIT_EXPECT_PTR_EQ(test, obj, NULL);
 }
 
+static struct drm_framebuffer *
+fb_create_addfb2_mock(struct drm_device *dev, struct drm_file *file_priv,
+		      const struct drm_mode_fb_cmd2 *cmd)
+{
+	struct drm_device_mock *mock = container_of(dev, typeof(*mock), dev);
+	struct drm_framebuffer *fb;
+
+	fb = kzalloc(sizeof(*fb), GFP_KERNEL);
+	if (!fb)
+		return ERR_PTR(-ENOMEM);
+
+	fb->base.id = 1;
+
+	mock->private = fb;
+	return fb;
+}
+
+static struct drm_mode_config_funcs config_funcs_addfb2_mock = {
+	.fb_create = fb_create_addfb2_mock,
+};
+
+static void drm_test_framebuffer_addfb2(struct kunit *test)
+{
+	struct drm_device_mock *mock = test->priv;
+	struct drm_device *dev = &mock->dev;
+	struct drm_file *file_priv = &mock->file_priv;
+	struct drm_framebuffer *fb = NULL;
+	int ret;
+
+	/* A valid cmd */
+	struct drm_mode_fb_cmd2 cmd = {
+		.width = 600, .height = 600,
+		.pixel_format = DRM_FORMAT_ABGR8888,
+		.handles = { 1, 0, 0 }, .pitches = { 4 * 600, 0, 0 },
+	};
+
+	dev->mode_config.funcs = &config_funcs_addfb2_mock;
+
+	/* Should fail due to missing DRIVER_MODESET support */
+	ret = drm_mode_addfb2(dev, &cmd, file_priv);
+	KUNIT_EXPECT_EQ(test, ret, -EOPNOTSUPP);
+	KUNIT_ASSERT_PTR_EQ(test, mock->private, NULL);
+
+	/* Set DRIVER_MODESET support */
+	dev->driver_features = dev->driver->driver_features;
+
+	/* Set an invalid cmd to trigger a fail on the
+	 * drm_internal_framebuffer_create function
+	 */
+	cmd.width = 0;
+	ret = drm_mode_addfb2(dev, &cmd, file_priv);
+	KUNIT_EXPECT_EQ(test, ret, -EINVAL);
+	KUNIT_ASSERT_PTR_EQ(test, mock->private, NULL);
+	cmd.width = 600; /* restore to a valid value */
+
+	/* Now there should be no errors */
+	ret = drm_mode_addfb2(dev, &cmd, file_priv);
+	KUNIT_EXPECT_EQ(test, ret, 0);
+
+	/* The fb_create_addfb2_mock set fb id to 1 */
+	KUNIT_EXPECT_EQ(test, cmd.fb_id, 1);
+
+	/* The framebuffer was properly allocated */
+	fb = mock->private;
+	KUNIT_ASSERT_NOT_ERR_OR_NULL(test, fb);
+
+	/* The fb should be properly added to the file_priv->fbs list */
+	KUNIT_EXPECT_PTR_EQ(test, file_priv->fbs.prev, &fb->filp_head);
+	KUNIT_EXPECT_PTR_EQ(test, file_priv->fbs.next, &fb->filp_head);
+
+	/* There should be just one fb on the list */
+	KUNIT_EXPECT_PTR_EQ(test, fb->filp_head.prev, &file_priv->fbs);
+	KUNIT_EXPECT_PTR_EQ(test, fb->filp_head.next, &file_priv->fbs);
+
+	kfree(fb);
+}
+
 static struct kunit_case drm_framebuffer_tests[] = {
+	KUNIT_CASE(drm_test_framebuffer_addfb2),
 	KUNIT_CASE(drm_test_framebuffer_cleanup),
 	KUNIT_CASE(drm_test_framebuffer_free),
 	KUNIT_CASE(drm_test_framebuffer_init),


### PR DESCRIPTION
This add tests for:

- Stop using dev_private on the test for `drm_internal_framebuffer_create()`
- Add tests for `drm_framebuffer_cleanup()`
- Add tests for `drm_framebuffer_lookup()`
- Add tests for `drm_framebuffer_init()`